### PR TITLE
Fix tap++ documentation error

### DIFF
--- a/tap++/doc/libtap++.pod
+++ b/tap++/doc/libtap++.pod
@@ -6,7 +6,7 @@ libtap++ - C++ unit tests for the Test Anything Protocol
 
 =head1 SYNOPSIS
 
-  #include <tap++.h>
+  #include <tap++/tap++.h>
   #include <string>
 
   using namespace TAP;


### PR DESCRIPTION
My latest commit fixes the documentation error I listed in issue #12
